### PR TITLE
Polybar: Update to 3.4.3 (Fixes #12)

### DIFF
--- a/polybar/debian/changelog
+++ b/polybar/debian/changelog
@@ -1,3 +1,9 @@
+polybar (3.4.3-0ubuntu0) focal; urgency=medium
+
+  * Update to 3.4.3
+
+ -- Jacob Babor <plr863@gmail.com>  Mon, 29 Jun 2020 05:33:41 -0500
+
 polybar (3.3.0-2-1ubuntu2) bionic; urgency=medium
 
   * Take Mr Risser's debian metadata for speed-ricer. 

--- a/polybar/debian/changelog
+++ b/polybar/debian/changelog
@@ -1,9 +1,3 @@
-polybar (3.4.3-0ubuntu0) focal; urgency=medium
-
-  * Update to 3.4.3
-
- -- Jacob Babor <plr863@gmail.com>  Mon, 29 Jun 2020 05:33:41 -0500
-
 polybar (3.3.0-2-1ubuntu2) bionic; urgency=medium
 
   * Take Mr Risser's debian metadata for speed-ricer. 

--- a/polybar/debian/control
+++ b/polybar/debian/control
@@ -24,7 +24,7 @@ Build-Depends: debhelper (>= 10),
                libxcb-xrm-dev,
                libxcb1-dev,
                pkg-config,
-               python-xcbgen,
+               python3-xcbgen,
                xcb-proto
 Standards-Version: 4.1.2
 Homepage: https://github.com/jaagr/polybar
@@ -42,7 +42,7 @@ Depends: ${shlibs:Depends}, ${misc:Depends},
          libxcb-randr0-dev,
          libxcb-util0-dev,
          libxcb1-dev,
-         python-xcbgen,
+         python3-xcbgen,
          xcb-proto
 Description: a fast and easy-to-use status bar
  Polybar aims to help users build beautiful and highly customizable status bars


### PR DESCRIPTION
This PR updates the Polybar package to version 3.4.3, fixing #12.

The package is, however, exclusive to Focal for a series of reasons:

* xpp had an unresolved bug that would cause it to attempt to use Python 2 even when a Python 3 version of `xcbgen` is installed. This bug was never fixed before support for Python 2 was simply dropped.

* Polybar hard depends on xpp

* Ubuntu 20.04 only ships `python3-xcbgen`

* Ubuntu 19.10 and earlier only ship `python-xcbgen` (the Python 2 version)

The source package for this was built from the upstream [Polybar](https://github.com/polybar/polybar) repo, tag `3.4.3` with the only addition of the `polybar/debian` directory, built with `dh_make --createorig` (no special args). The binary package was then built with `pbuilder --distribution focal --architecture amd64`.

The resultant `.deb` was installed on a 20.04 VM and tested with [my personal configs](https://git.9iron.club/salt/home/src/branch/master/.config/polybar/config). Everything worked out of the box, but some users may encounter errors depending on what configuration options were deprecated or removed in 3.4.

This is my first attempt at pushing a change to a PPA, so if I did something wrong, let me know. In particular, the only instance of "Focal" in the diffs being in one line of a changelog strikes me as probably wrong, given the circumstance. I can also provide my own build artifacts if you need those, too.